### PR TITLE
add option "retain_key_combinations"

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -11,6 +11,7 @@ Simple Calculate messages and summarize the calculated results.
 - Use finalizer of summarized results (e.g. average)
 
 'input_tag_remove_prefix' option available if you want to remove tag prefix from output field names.
+'retain_key_combinations' option available if you want to retain key combination created in previous to next interval (default => true).
 
 == Configuration
 

--- a/example.conf
+++ b/example.conf
@@ -7,6 +7,7 @@
   tag result.quest
   count_interval 5s
   aggregate keys area_id, mission_id
+  retain_key_combinations false
   formulas sum = amount * price, cnt = 1, total = amount
   finalizer ave = cnt > 0 ? 1.00 * sum / cnt : 0
 	<unmatched>

--- a/lib/fluent/plugin/out_datacalculator.rb
+++ b/lib/fluent/plugin/out_datacalculator.rb
@@ -10,6 +10,7 @@ class Fluent::DataCalculatorOutput < Fluent::Output
   config_param :input_tag_remove_prefix, :string, :default => nil
   config_param :formulas, :string
   config_param :finalizer, :string, :default => nil
+  config_param :retain_key_combinations, :bool, :default => true
 
   attr_accessor :tick
   attr_accessor :counts
@@ -242,7 +243,11 @@ class Fluent::DataCalculatorOutput < Fluent::Output
   end
 
   def flush(step)
-    flushed, @counts = @counts,count_initialized(@counts.keys.dup)
+    if @retain_key_combinations
+      flushed, @counts = @counts,count_initialized(@counts.keys.dup)
+    else
+      flushed, @counts = @counts,count_initialized
+    end
     generate_output(flushed, step)
   end
 

--- a/test/plugin/test_out_datacalculator.rb
+++ b/test/plugin/test_out_datacalculator.rb
@@ -240,4 +240,38 @@ class DataCalculatorOutputTest < Test::Unit::TestCase
       assert_equal counts[pat], r['count']
     end
   end
+
+  def test_flush
+    # retain_key_combinations is true
+    d1 = create_driver(%[
+      unit minute
+      aggregate keys area_id, mission_id
+      formulas sum = amount * price, count = 1
+      retain_key_combinations true
+    ], 'test.input')
+    d1.run do
+      60.times do
+        d1.emit({'area_id' => 1, 'mission_id' => 1, 'amount' => 3, 'price' => 100})
+        d1.emit({'area_id' => 2, 'mission_id' => 1, 'amount' => 3, 'price' => 100})
+      end
+    end
+    assert_equal d1.instance.flush(60).size, 2
+    assert_equal d1.instance.flush(60).size, 2
+
+    # retain_key_combinations is false
+    d2 = create_driver(%[
+      unit minute
+      aggregate keys area_id, mission_id
+      formulas sum = amount * price, count = 1
+      retain_key_combinations false
+    ], 'test.input')
+    d2.run do
+      60.times do
+        d2.emit({'area_id' => 1, 'mission_id' => 1, 'amount' => 3, 'price' => 100})
+        d2.emit({'area_id' => 2, 'mission_id' => 1, 'amount' => 3, 'price' => 100})
+      end
+    end
+    assert_equal d2.instance.flush(60).size, 2
+    assert_equal d2.instance.flush(60).size, 0
+  end
 end


### PR DESCRIPTION
いきなりのpull request失礼します。

現状の仕様ですと、過去に作成したキーの組合せがずっと引き継がれるようになっていますが、
たまにしか出ない組合せでもインターバル毎に値が0で生成されてしまいますので、
引き継ぐかどうかをオプションで指定出来るように変更致しました。

ご確認、よろしくお願い致します。
